### PR TITLE
Fix BlogCard styling by updating windmolen to latest version

### DIFF
--- a/pages/styles.css
+++ b/pages/styles.css
@@ -15,3 +15,7 @@ body > div {
   height: 1px;
   overflow: hidden;
 }
+
+.Card-module__Card .Card-module__content {
+  padding: 30px 0;
+}


### PR DESCRIPTION
The previous version of windmolen set the padding of the BlogCard to all sides, the new version only sets vertical padding.